### PR TITLE
Allow injection of updated in atom formatter

### DIFF
--- a/slacklog/formatters.py
+++ b/slacklog/formatters.py
@@ -459,6 +459,8 @@ class SlackLogAtomFormatter (SlackLogFormatter):
         """:py:class:`unicode`.  Name of the feed author."""
         self.email = None
         """:py:class:`unicode`.  Email of the feed author."""
+        self.updated = None
+        """:py:class:`datetime.datetime`.  Timestamp when this feed was last generated."""
 
     def format_log_preamble(self, log):
         """
@@ -478,7 +480,10 @@ class SlackLogAtomFormatter (SlackLogFormatter):
             data += u'    <link href="%s" />\n' % self.webLink
         else:
             data += u'    <link href="%s" />\n' % self.link
-        data += u'    <updated>%s</updated>\n' % datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        if self.updated:
+            data += u'    <updated>%s</updated>\n' % self.updated.strftime("%Y-%m-%dT%H:%M:%SZ")
+        else:
+            data += u'    <updated>%s</updated>\n' % datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         data += u'    <author>\n'
         data += u'        <name>%s</name>\n' % self.name
         data += u'        <email>%s</email>\n' % self.email

--- a/slacklog/scripts.py
+++ b/slacklog/scripts.py
@@ -143,7 +143,9 @@ def slacklog2atom():
             'name': {'help': 'NAME of the feed author',
                      'metavar': 'NAME'},
             'email': {'help': 'EMAIL of the feed author',
-                      'metavar': 'EMAIL'}
+                      'metavar': 'EMAIL'},
+            'updated': {'help': 'Timestamp when this feed was last generated.',
+                        'metavar': 'DATE'}
         })
 
     #
@@ -160,6 +162,7 @@ def slacklog2atom():
     formatter.webLink = u(opts.webLink)
     formatter.name = u(opts.name)
     formatter.email = u(opts.email)
+    formatter.updated = parser.parse_date(u(opts.updated))
 
     #
     #   Read input


### PR DESCRIPTION
Closes #4 

In addition to making it more testable, makes it possible to use the latest patch timestamp to be used as feed update timestamp (not automatically, but still).